### PR TITLE
No contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing
+
+`scikit-optimize` is an open-source project and contributions of all kinds
+are welcome.
+
+Code contributions should follow these guidelines:
+
+* all changes by pull request (PR)
+* a PR solves one problem (do not mix problems together in one PR) with the
+  minimal set of changes
+* describe why you are proposing the changes you are proposing
+* try to not rush changes (the definition of rush depends on how big your
+  changes are)
+* someone else has to merge your PR
+* new code needs to come with a test
+* no merging if travis is red
+
+These are not hard rules to be enforced by :police_car: but instead guidelines.


### PR DESCRIPTION
Added a inimal contribution guide in `CONTRIBUTING.md`. It lacks some details
on the mechanics of actually contributing.

NB. we should pick a license