### PR TITLE
Make gp_acquisition_func public

### DIFF
--- a/examples/plot_1d_demo.py
+++ b/examples/plot_1d_demo.py
@@ -54,6 +54,5 @@ def plot_interactive_gp(func, bounds, random_state, max_iter=1000):
 
     plt.show()
 
-
 plot_interactive_gp(parabola, (-1, 1), 0, 100)
 # x, f, d = plot_interactive_gp(sin, (-2, 2), 0, 100)

--- a/skopt/__init__.py
+++ b/skopt/__init__.py
@@ -1,1 +1,1 @@
-from .gp_opt import gp_minimize
+from .gp_opt import gp_minimize, gp_acquisition_func

--- a/skopt/__init__.py
+++ b/skopt/__init__.py
@@ -1,1 +1,1 @@
-from .gp_opt import gp_minimize, gp_acquisition_func
+from .gp_opt import gp_minimize, acquisition_func


### PR DESCRIPTION
A minor pull request to make `_acquistion_func` public. Also renamed it as `gp_acquisition_func` since the actual acquisition function depends on the distribution of the posterior